### PR TITLE
將 ems 匯出的講者檔案轉換成官網用的講者資料

### DIFF
--- a/pure_php/convert_speaker.php
+++ b/pure_php/convert_speaker.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * $ php conver_speaker.php input_tsv output_json
+ */
+
+$extraField = [
+    'started_at' => '',
+    'ended_at' => '',
+    'room' => '',
+    'floor' => '',
+    'sponsor_id' => 0,
+];
+
+$file = $argv[1];
+$target = $argv[2];
+if (!file_exists($file)) {
+    echo "File not found";
+    die();
+}
+$data = [];
+$producionData = file_exists($target) ? json_decode(file_get_contents($target), true) : [];
+if (count($producionData) > 0) {
+    foreach ($producionData as $speaker) {
+        $data[$speaker['speaker_id']] = $speaker;
+    }
+}
+
+$f = fopen($file, 'r');
+$firstLine = true;
+
+while (($row = fgets($f)) !== false) {
+    if ($firstLine) {
+        $firstLine = false;
+        continue;
+    }
+    $row = trim($row);
+    $result = explode("\t", $row);
+
+    array_walk_recursive($result, function (&$value) {
+        $value = str_replace(array('\\x22','\\x27','\\n'), array("'",'"',"\n"), $value);
+    });
+    //tag filter empty
+    $result[18] = $result[18] == '' ? [] : explode(',', $result[18]);
+    //convert keynote
+    $result[29] = $result[29] === '是';
+    $newData = [
+        'name' => $result[1],
+        'name_e' => $result[2],
+        'speaker_id' => (int) $result[0],
+        'company' => $result[3],
+        'company_e' => $result[4],
+        'job_title' => $result[5],
+        'job_title_e' => $result[6],
+        'bio' => $result[7],
+        'bio_e' => $result[8],
+        'photo_for_speaker_web' => 'api/2019/speaker/images/web/speaker_' . (string)$result[0],
+        'photo_for_speaker_mobile' => 'api/2019/speaker/images/mobile/speaker_' . (string)$result[0],
+        'photo_for_session_web' => 'api/2019/speaker/images/web/speaker_' . (string)$result[0],
+        'photo_for_session_mobile' => 'api/2019/speaker/images/mobile/speaker_' . (string)$result[0],
+        'photo_for_sponsor_web' => 'api/2019/speaker/images/web/speaker_' . (string)$result[0],
+        'photo_for_sponsor_mobile' => 'api/2019/speaker/images/mobile/speaker_' . (string)$result[0],
+        'link_fb' => $result[10],
+        'link_github' => $result[11],
+        'link_twitter' => $result[12],
+        'link_other' => $result[13],
+        'topic' => $result[14],
+        'topic_e' => $result[15],
+        'summary' => $result[16],
+        'summary_e' => $result[17],
+        'is_keynote' => $result[29],
+        'recordable' => $result[20] == '謝絕所有錄音錄影，但接受 MOPCON 工作人員文字紀錄。' ? false : true,
+        'level' => explode('-', $result[15])[0],
+        'tags' => $result[18],
+    ];
+
+    if (array_key_exists($newData['speaker_id'], $data)) {
+        $oldData = $data[$newData['speaker_id']];
+        $data[$newData['speaker_id']] = array_replace($oldData, $newData);
+    } else {
+        $data[$newData['speaker_id']] = array_merge($newData, $extraField);
+    }
+}
+ksort($data);
+
+file_put_contents($target, json_encode(array_values($data), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));


### PR DESCRIPTION
整合 @hashman 和 @FWcloud916 的轉換程式，加上保留原本資料的設定。

+ 轉檔指令改成 `$ php conver_speaker.php input_tsv output_json` 。
+ tsv 不需每次都匯出全部講者，可以只匯出需要更新或新增的講者資料。
+ 更新講者資料除了特定欄位直接修改 json 之外，其他資料直接利用 ems 匯出的檔案更新，如果有需要修正的地方請直接更新 ems 資料庫後再匯出檔案後重新轉檔。
+ 需要直接修改 json 的欄位
  + ‘started_at’
  + ‘ended_at’
  + ‘room’
  + ‘floor’
  + ‘sponsor_id’